### PR TITLE
Changes to prompt structure and environment setup structure

### DIFF
--- a/src/environments/resources.nlogo
+++ b/src/environments/resources.nlogo
@@ -59,6 +59,7 @@ to setup
   clear-all
 
   py:setup py:python
+  py:setup "/Users/rudydanda/.rye/shims/python"
   py:run "import os"
   py:run "import sys"
   py:run "from pathlib import Path"
@@ -103,10 +104,10 @@ to setup-resources
     let spawn-location one-of patches with [not any? turtles-here]
     if spawn-location != nobody [
       create-resources 1 [
-        ;move-to spawn-location
-        setxy 0 0
-        fd resource-radius
-        set resource-kind one-of resource-types
+        move-to spawn-location
+;        setxy 0 0
+;        fd resource-radius
+        set resource-kind weighted-resource-kind
         set shape resource-kind
         set color (ifelse-value (resource-kind = "silver") [gray]
                               (resource-kind = "gold") [yellow]
@@ -117,6 +118,14 @@ to setup-resources
     ]
   ]
 end
+
+to-report weighted-resource-kind
+  let r random-float 1
+  if r < 0.5 [ report "silver" ]
+  if r < 0.85 [ report "gold" ]  ;; 0.5 to 0.85
+  report "crystal"               ;; 0.85 to 1
+end
+
 
 to setup-llm-agents
   create-llm-agents num-llm-agents [
@@ -151,10 +160,10 @@ to replenish-resources
       let spawn-location one-of patches with [not any? turtles-here]
       if spawn-location != nobody [
         create-resources 1 [
-          ;move-to spawn-location
-          setxy 0 0
-          fd resource-radius
-          set resource-kind one-of ["silver" "gold" "crystal"]
+          move-to spawn-location
+;          setxy 0 0
+;          fd resource-radius
+          set resource-kind weighted-resource-kind
 
           ;; Assign visual properties
           if resource-kind = "silver" [ set shape "silver" set color gray ]
@@ -175,8 +184,8 @@ to go
   ask llm-agents [
     set lifetime lifetime + 1
     set distance-from-center distancexy 0 0
-    set resource-score resource-score - (weight * 0.25)  ;; Lose resource-score at a rate of 25% of total weight
-    set resource-deposited resource-deposited - (weight * 0.25)  ;; Lose resource-deposited at a rate of 25% of total weight
+    set resource-score resource-score - (weight * 0.03)  ;; Lose resource-score at a rate of 10% of total weight
+    set resource-deposited resource-deposited - (weight * 0.03)  ;; Lose resource-deposited at a rate of 10% of total weight
 
     ;; set resource-score resource-score - (weight ^ 1.5 * 0.1) ;; exponential loss (higher weights are punished more)
     ;; if weight > 2 [ set resource-score resource-score - ((weight - 2) * 0.3) ] ;; start losing weight once over a threshold
@@ -293,12 +302,6 @@ to pick-up
     ;; ----- Resource Score calculation: incremented when picking up
     set resource-score resource-score + value
     ;; print (word "PICKED UP: " kind " | New Score: " resource-score) ## DEBUGGING!!!
-
-;    let keys table:keys inventory
-;    foreach keys [ key ->
-;      let val (ifelse-value (key = "silver") [1] (key = "gold") [2] [4])
-;      set resource-score resource-score + (table:get inventory key) * val
-;    ]
 
     set weight weight + weight-addition
 
@@ -720,7 +723,7 @@ resource-radius
 resource-radius
 0
 25
-12.0
+19.0
 1
 1
 NIL

--- a/src/utils/storeprompts.py
+++ b/src/utils/storeprompts.py
@@ -2527,9 +2527,8 @@ ifelse member? "crystal" input-resource-types and any? map [i -> (item i input-r
        {}
      ```
      INPUT CONTEXT:
-     - You have access to variables called input-resource-distances, input-resource-types, and weight
+     - You have access to variables called input-resource-distances and weight
      - input-resource-distances is a NetLogo list that contains three values representing distances to food in three cone regions of 20 degrees each. 
-     - input-resource-types is a NetLogo list that contains three resource types that are either “silver”, “gold” or “crystal. The input-resource-types list is parallel to the input-resource-distances list, which means their element indices correspond to the same resource.
      - The first item in input-resource-distances is the distance to the nearest resource in the left cone, the second is the right cone, and the third is the front cone
      - Non-zero lower values in input-resource-distances indicate closer resources
      - Use the information in this variable to inform movement strategy
@@ -2591,9 +2590,8 @@ ifelse member? "crystal" input-resource-types and any? map [i -> (item i input-r
        {}
      ```
      INPUT CONTEXT:
-     - You have access to variables called input-resource-distances, input-resource-types, and weight
+     - You have access to variables called input-resource-distances and weight
      - input-resource-distances is a NetLogo list that contains three values representing distances to food in three cone regions of 20 degrees each. 
-     - input-resource-types is a NetLogo list that contains three resource types that are either “silver”, “gold” or “crystal. The input-resource-types list is parallel to the input-resource-distances list, which means their element indices correspond to the same resource.
      - The first item in input-resource-distances is the distance to the nearest resource in the left cone, the second is the right cone, and the third is the front cone
      - Non-zero lower values in input-resource-distances indicate closer resources
      - Use the information in this variable to inform movement strategy
@@ -2643,9 +2641,34 @@ ifelse member? "crystal" input-resource-types and any? map [i -> (item i input-r
      4. Be creative in your movement strategy
      EXAMPLES OF VALID CODE GENERATION:
      Current Code: ```fd 1 rt random 45 fd 2 lt 30```
-     Changed Code: ```ifelse (item 0 input-resource-distances != 0) [ ifelse (item 0 input-resource-types = "gold") [ rt 15 fd 0.5 ] [ rt random 30 lt random 30 fd 5 ] ] [ rt random 30 lt random 30 fd 5 ]
-```
-     Why: This code uses two parallel lists—input-resource-distances and input-resource-types—to guide movement based on what's detected in the left cone. If a resource is present (non-zero distance) and it's "gold", the agent turns slightly and moves forward to approach it. Otherwise, it turns randomly and moves further to explore the environment.
+     Changed Code: ```ifelse weight > 50 [
+  if xcor > 0 [ rt 10 ]
+  if xcor < 0 [ lt 10 ]
+  if ycor > 0 [ rt 10 ]
+  if ycor < 0 [ lt 10 ]
+  fd 2
+][
+  if item 0 input-resource-distances <= item 1 input-resource-distances and item 0 input-resource-distances <= item 2 input-resource-distances [
+    if item 0 input-resource-distances < 5 [ rt 5 ]
+    lt 20
+  ]
+  if item 1 input-resource-distances <= item 0 input-resource-distances and item 1 input-resource-distances <= item 2 input-resource-distances [
+    if item 1 input-resource-distances < 5 [ lt 5 ]
+    rt 20
+  ]
+  if item 2 input-resource-distances <= item 0 input-resource-distances and item 2 input-resource-distances <= item 1 input-resource-distances [
+    if item 2 input-resource-distances < 5 [ rt 5 ]
+    rt 10
+  ]
+  if item 0 input-resource-distances > 10 and item 1 input-resource-distances > 10 and item 2 input-resource-distances > 10 [
+    if xcor > 0 [ rt 10 ]
+    if xcor < 0 [ lt 10 ]
+    if ycor > 0 [ rt 10 ]
+    if ycor < 0 [ lt 10 ]
+  ]
+  fd 1
+]```
+     Why: Code controls a movement based on agent weight and input-resource-distances. If the agent is heavy (weight > 30), it returns to the center (for depositing) by turning based on its position and moving forward quickly. If it is light (weight < 30), it seeks the closest resource by comparing distances in the list and turning toward the nearest one with a small angle adjustment, then moves forward slowly. This creates a simple foraging-return behavior.
      The code must be runnable in NetLogo in the context of a turtle. Do not write any procedures and assume that the code will be run in an ask turtles block.
      Return ONLY the changed NetLogo code. Do not include any explanations or outside the code block.
      ```
@@ -2660,9 +2683,8 @@ ifelse member? "crystal" input-resource-types and any? map [i -> (item i input-r
        {}
      ```
      INPUT CONTEXT:
-     - You have access to variables called input-resource-distances, input-resource-types, and weight
+     - You have access to variables called input-resource-distances and weight
      - input-resource-distances is a NetLogo list that contains three values representing distances to food in three cone regions of 20 degrees each. 
-     - input-resource-types is a NetLogo list that contains three resource types that are either “silver”, “gold” or “crystal. The input-resource-types list is parallel to the input-resource-distances list, which means their element indices correspond to the same resource.
      - The first item in input-resource-distances is the distance to the nearest resource in the left cone, the second is the right cone, and the third is the front cone
      - Non-zero lower values in input-resource-distances indicate closer resources
      - Use the information in this variable to inform movement strategy
@@ -2712,276 +2734,156 @@ ifelse member? "crystal" input-resource-types and any? map [i -> (item i input-r
      4. Be creative in your movement strategy
      EXAMPLES OF VALID CODE GENERATION:
      Current Code: ```fd 1 rt random 45 fd 2 lt 30```
-     Changed Code: ```ifelse (item 0 input-resource-distances != 0) [ ifelse (item 0 input-resource-types = "gold") [ rt 15 fd 0.5 ] [ rt random 30 lt random 30 fd 5 ] ] [ rt random 30 lt random 30 fd 5 ]
-```
-     Why: This code uses two parallel lists—input-resource-distances and input-resource-types—to guide movement based on what's detected in the left cone. If a resource is present (non-zero distance) and it's "gold", the agent turns slightly and moves forward to approach it. Otherwise, it turns randomly and moves further to explore the environment.
+     Changed Code: ```ifelse weight > 50 [
+  if xcor > 0 [ rt 10 ]
+  if xcor < 0 [ lt 10 ]
+  if ycor > 0 [ rt 10 ]
+  if ycor < 0 [ lt 10 ]
+  fd 2
+][
+  if item 0 input-resource-distances <= item 1 input-resource-distances and item 0 input-resource-distances <= item 2 input-resource-distances [
+    if item 0 input-resource-distances < 5 [ rt 5 ]
+    lt 20
+  ]
+  if item 1 input-resource-distances <= item 0 input-resource-distances and item 1 input-resource-distances <= item 2 input-resource-distances [
+    if item 1 input-resource-distances < 5 [ lt 5 ]
+    rt 20
+  ]
+  if item 2 input-resource-distances <= item 0 input-resource-distances and item 2 input-resource-distances <= item 1 input-resource-distances [
+    if item 2 input-resource-distances < 5 [ rt 5 ]
+    rt 10
+  ]
+  if item 0 input-resource-distances > 10 and item 1 input-resource-distances > 10 and item 2 input-resource-distances > 10 [
+    if xcor > 0 [ rt 10 ]
+    if xcor < 0 [ lt 10 ]
+    if ycor > 0 [ rt 10 ]
+    if ycor < 0 [ lt 10 ]
+  ]
+  fd 1
+]```
+     Why: The code controls the movement based on agent weight and input-resource-distances. If the agent is heavy (weight > 30), it returns to the center (for depositing) by turning based on its position and moving forward quickly. If it is light (weight < 30), it seeks the closest resource by comparing distances in the list and turning toward the nearest one with a small angle adjustment, then moves forward slowly. This creates a simple foraging-return behavior.
      Current Code:
      ```
-     ifelse (item 0 input-resource-distances != 0) [
-  ifelse (item 0 input-resource-types = "gold") [
-    lt 5
-    fd 0.2
-  ] [
-    ifelse (item 1 input-resource-distances != 0) [
-      ifelse (item 1 input-resource-types = "silver") [
-        rt 5
-        fd 0.2
-      ] [
-        ifelse (item 2 input-resource-distances != 0) [
-          ifelse (item 2 input-resource-types = "crystal") [
-            fd 0.2
-          ] [
-            ifelse (random 100 < 50) [
-              fd 2
-              rt random-float 45
-            ] [
-              rt random-float 30
-              fd 5
-            ]
-          ]
-        ] [
-          ifelse (random 100 < 50) [
-            fd 2
-            rt random-float 45
-          ] [
-            rt random-float 30
-            fd 5
-          ]
-        ]
-      ]
-    ] [
-      ifelse (item 2 input-resource-distances != 0) [
-        ifelse (item 2 input-resource-types = "crystal") [
-          fd 0.2
-        ] [
-          ifelse (random 100 < 50) [
-            fd 2
-            rt random-float 45
-          ] [
-            rt random-float 30
-            fd 5
-          ]
-        ]
-      ] [
-        ifelse (random 100 < 50) [
-          fd 2
-          rt random-float 45
-        ] [
-          rt random-float 30
-          fd 5
-        ]
-      ]
-    ]
+     ifelse weight > 50 [
+  if xcor > 0 [ rt 10 ]
+  if xcor < 0 [ lt 10 ]
+  if ycor > 0 [ rt 10 ]
+  if ycor < 0 [ lt 10 ]
+  fd 2
+][
+  if item 0 input-resource-distances <= item 1 input-resource-distances and item 0 input-resource-distances <= item 2 input-resource-distances [
+    if item 0 input-resource-distances < 5 [ rt 5 ]
+    lt 20
   ]
-] [
-  ifelse (item 1 input-resource-distances != 0) [
-    ifelse (item 1 input-resource-types = "silver") [
-      rt 5
-      fd 0.2
-    ] [
-      ifelse (item 2 input-resource-distances != 0) [
-        ifelse (item 2 input-resource-types = "crystal") [
-          fd 0.2
-        ] [
-          ifelse (random 100 < 50) [
-            fd 2
-            rt random-float 45
-          ] [
-            rt random-float 30
-            fd 5
-          ]
-        ]
-      ] [
-        ifelse (random 100 < 50) [
-          fd 2
-          rt random-float 45
-        ] [
-          rt random-float 30
-          fd 5
-        ]
-      ]
-    ]
-  ] [
-    ifelse (item 2 input-resource-distances != 0) [
-      ifelse (item 2 input-resource-types = "crystal") [
-        fd 0.2
-      ] [
-        ifelse (random 100 < 50) [
-          fd 2
-          rt random-float 45
-        ] [
-          rt random-float 30
-          fd 5
-        ]
-      ]
-    ] [
-      ifelse (random 100 < 50) [
-        fd 2
-        rt random-float 45
-      ] [
-        rt random-float 30
-        fd 5
-      ]
-    ]
+  if item 1 input-resource-distances <= item 0 input-resource-distances and item 1 input-resource-distances <= item 2 input-resource-distances [
+    if item 1 input-resource-distances < 5 [ lt 5 ]
+    rt 20
   ]
+  if item 2 input-resource-distances <= item 0 input-resource-distances and item 2 input-resource-distances <= item 1 input-resource-distances [
+    if item 2 input-resource-distances < 5 [ rt 5 ]
+    rt 10
+  ]
+  if item 0 input-resource-distances > 10 and item 1 input-resource-distances > 10 and item 2 input-resource-distances > 10 [
+    if xcor > 0 [ rt 10 ]
+    if xcor < 0 [ lt 10 ]
+    if ycor > 0 [ rt 10 ]
+    if ycor < 0 [ lt 10 ]
+  ]
+  fd 1
 ]
      
      ```
      Changed Code:
      ```
-ifelse member? "crystal" input-resource-types [
-  ifelse any? map [i -> (item i input-resource-types = "crystal") and (item i input-resource-distances != 0)] [0 1 2] [
-    ifelse (item 0 input-resource-types = "crystal") [
-      ifelse (item 0 input-resource-distances != 0) [
-        ifelse ((item 1 input-resource-types != "crystal") or (item 0 input-resource-distances <= item 1 input-resource-distances)) [
-          ifelse ((item 2 input-resource-types != "crystal") or (item 0 input-resource-distances <= item 2 input-resource-distances)) [
-            lt 5
-            fd 0.2
-          ] [
-            fd 0.2
-          ]
-        ] [
-          fd 0.2
-        ]
-      ] [
-        fd 0.2
-      ]
-    ] [
-      ifelse (item 1 input-resource-types = "crystal") [
-        ifelse (item 1 input-resource-distances != 0) [
-          ifelse ((item 0 input-resource-types != "crystal") or (item 1 input-resource-distances <= item 0 input-resource-distances)) [
-            ifelse ((item 2 input-resource-types != "crystal") or (item 1 input-resource-distances <= item 2 input-resource-distances)) [
-              rt 5
-              fd 0.2
-            ] [
-              fd 0.2
-            ]
-          ] [
-            fd 0.2
-          ]
-        ] [
-          fd 0.2
-        ]
-      ] [
-        fd 0.2
-      ]
+ifelse weight > 50 [
+  if xcor > 0 [ rt 10 ]
+  if xcor < 0 [ lt 10 ]
+  if ycor > 0 [ rt 10 ]
+  if ycor < 0 [ lt 10 ]
+  fd 2
+][
+  if item 0 input-resource-distances <= item 1 input-resource-distances and item 0 input-resource-distances <= item 2 input-resource-distances [
+    if item 0 input-resource-distances < 5 [ rt 5 ]
+    lt 20
+    fd 1.5
+  ]
+  if item 1 input-resource-distances <= item 0 input-resource-distances and item 1 input-resource-distances <= item 2 input-resource-distances [
+    if item 1 input-resource-distances < 5 [ lt 5 ]
+    rt 20
+    fd 1.5
+  ]
+  if item 2 input-resource-distances <= item 0 input-resource-distances and item 2 input-resource-distances <= item 1 input-resource-distances [
+    if item 2 input-resource-distances < 5 [ rt 5 ]
+    rt 10
+    fd 1.5
+  ]
+  if item 0 input-resource-distances > 10 and item 1 input-resource-distances > 10 and item 2 input-resource-distances > 10 [
+    if abs(xcor) > abs(ycor) [ 
+      if xcor > 0 [ rt 10 ]
+      if xcor < 0 [ lt 10 ]
     ]
-  ] [ ; no valid "crystal"
-    ifelse member? "gold" input-resource-types [
-      ifelse any? map [i -> (item i input-resource-types = "gold") and (item i input-resource-distances != 0)] [0 1 2] [
-        ifelse (item 0 input-resource-types = "gold") [
-          ifelse (item 0 input-resource-distances != 0) [
-            ifelse ((item 1 input-resource-types != "gold") or (item 0 input-resource-distances <= item 1 input-resource-distances)) [
-              ifelse ((item 2 input-resource-types != "gold") or (item 0 input-resource-distances <= item 2 input-resource-distances)) [
-                lt 5
-                fd 0.2
-              ] [
-                fd 0.2
-              ]
-            ] [
-              fd 0.2
-            ]
-          ] [
-            fd 0.2
-          ]
-        ] [
-          ifelse (item 1 input-resource-types = "gold") [
-            ifelse (item 1 input-resource-distances != 0) [
-              ifelse ((item 0 input-resource-types != "gold") or (item 1 input-resource-distances <= item 0 input-resource-distances)) [
-                ifelse ((item 2 input-resource-types != "gold") or (item 1 input-resource-distances <= item 2 input-resource-distances)) [
-                  rt 5
-                  fd 0.2
-                ] [
-                  fd 0.2
-                ]
-              ] [
-                fd 0.2
-              ]
-            ] [
-              fd 0.2
-            ]
-          ] [
-            fd 0.2
-          ]
-        ]
-      ] [ ; no valid "gold"
-        ifelse member? "silver" input-resource-types [
-          ifelse any? map [i -> (item i input-resource-types = "silver") and (item i input-resource-distances != 0)] [0 1 2] [
-            ifelse (item 0 input-resource-types = "silver") [
-              ifelse (item 0 input-resource-distances != 0) [
-                ifelse ((item 1 input-resource-types != "silver") or (item 0 input-resource-distances <= item 1 input-resource-distances)) [
-                  ifelse ((item 2 input-resource-types != "silver") or (item 0 input-resource-distances <= item 2 input-resource-distances)) [
-                    lt 5
-                    fd 0.2
-                  ] [
-                    fd 0.2
-                  ]
-                ] [
-                  fd 0.2
-                ]
-              ] [
-                fd 0.2
-              ]
-            ] [
-              ifelse (item 1 input-resource-types = "silver") [
-                ifelse (item 1 input-resource-distances != 0) [
-                  ifelse ((item 0 input-resource-types != "silver") or (item 1 input-resource-distances <= item 0 input-resource-distances)) [
-                    ifelse ((item 2 input-resource-types != "silver") or (item 1 input-resource-distances <= item 2 input-resource-distances)) [
-                      rt 5
-                      fd 0.2
-                    ] [
-                      fd 0.2
-                    ]
-                  ] [
-                    fd 0.2
-                  ]
-                ] [
-                  fd 0.2
-                ]
-              ] [
-                fd 0.2
-              ]
-            ]
-          ] [ ; no valid "silver"
-            ifelse random 100 < 50 [
-              fd 2
-              rt random-float 45
-            ] [
-              rt random-float 30
-              fd 5
-            ]
-          ]
-        ] [ ; not even "silver"
-          ifelse random 100 < 50 [
-            fd 2
-            rt random-float 45
-          ] [
-            rt random-float 30
-            fd 5
-          ]
-        ]
-      ]
-    ] [ ; not even "gold"
-      ifelse random 100 < 50 [
-        fd 2
-        rt random-float 45
-      ] [
-        rt random-float 30
-        fd 5
-      ]
+    if abs(xcor) < abs(ycor) [ 
+      if ycor > 0 [ rt 10 ]
+      if ycor < 0 [ lt 10 ]
+    ]
+    if abs(xcor) = 0 and abs(ycor) = 0 [ fd 1 ]
+    fd 1
+  ]
+  if item 0 input-resource-distances > 5 and item 1 input-resource-distances > 5 and item 2 input-resource-distances > 5 [
+    if xcor > 0 [ rt 5 ]
+    if xcor < 0 [ lt 5 ]
+    if ycor > 0 [ rt 5 ]
+    if ycor < 0 [ lt 5 ]
+    fd 1
+  ]
+  if xcor = 0 and ycor = 0 [
+    if item 0 input-resource-distances < item 1 input-resource-distances and item 0 input-resource-distances < item 2 input-resource-distances [
+      if item 0 input-resource-distances < 5 [ rt 5 ]
+      lt 20
+      fd 1.5
+    ]
+    if item 1 input-resource-distances < item 0 input-resource-distances and item 1 input-resource-distances < item 2 input-resource-distances [
+      if item 1 input-resource-distances < 5 [ lt 5 ]
+      rt 20
+      fd 1.5
+    ]
+    if item 2 input-resource-distances < item 0 input-resource-distances and item 2 input-resource-distances < item 1 input-resource-distances [
+      if item 2 input-resource-distances < 5 [ rt 5 ]
+      rt 10
+      fd 1.5
     ]
   ]
-] [
-  ifelse random 100 < 50 [
+  if abs(xcor) < 5 and abs(ycor) < 5 and weight > 10 [
+    if xcor > 0 [ rt 10 ]
+    if xcor < 0 [ lt 10 ]
+    if ycor > 0 [ rt 10 ]
+    if ycor < 0 [ lt 10 ]
     fd 2
-    rt random-float 45
-  ] [
-    rt random-float 30
-    fd 5
+  ]
+  if abs(xcor) < 10 and abs(ycor) < 10 and weight > 20 [
+    if xcor > 0 [ rt 10 ]
+    if xcor < 0 [ lt 10 ]
+    if ycor > 0 [ rt 10 ]
+    if ycor < 0 [ lt 10 ]
+    fd 2
+  ]
+  if abs(xcor) > 10 or abs(ycor) > 10 and weight < 10 [
+    if xcor > 0 [ lt 5 ]
+    if xcor < 0 [ rt 5 ]
+    if ycor > 0 [ lt 5 ]
+    if ycor < 0 [ rt 5 ]
+    fd 1
+  ]
+  if weight > 30 [
+    if xcor > 0 [ rt 10 ]
+    if xcor < 0 [ lt 10 ]
+    if ycor > 0 [ rt 10 ]
+    if ycor < 0 [ lt 10 ]
+    fd 2
   ]
 ]
      ```
-     Why: This code directs the agent to move toward the closest instance of the highest-value resource it can detect—crystal first, then gold, then silver—based on distances in three vision cones (left, right, front), and defaults to random wandering if no resources are seen.
+     Why: The evolved code adds more nuanced behaviors based on the agent's position, weight, and proximity to resources. It introduces finer movement control (fd 1.5), special cases for being near or at the center, and multiple fallback strategies to improve adaptability. These changes help the agent navigate more intelligently, avoid getting stuck, and better balance between exploring and returning behavior.
      The code must be runnable in NetLogo in the context of a turtle. Do not write any procedures and assume that the code will be run in an ask turtles block.
      Return ONLY the changed NetLogo code. Do not include any explanations or outside the code block.
      ```
@@ -2996,9 +2898,8 @@ ifelse member? "crystal" input-resource-types [
        {}
      ```
      INPUT CONTEXT:
-     - You have access to variables called input-resource-distances, input-resource-types, and weight
+     - You have access to variables called input-resource-distances and weight
      - input-resource-distances is a NetLogo list that contains three values representing distances to food in three cone regions of 20 degrees each. 
-     - input-resource-types is a NetLogo list that contains three resource types that are either “silver”, “gold” or “crystal. The input-resource-types list is parallel to the input-resource-distances list, which means their element indices correspond to the same resource.
      - The first item in input-resource-distances is the distance to the nearest resource in the left cone, the second is the right cone, and the third is the front cone
      - Non-zero lower values in input-resource-distances indicate closer resources
      - Use the information in this variable to inform movement strategy
@@ -3061,9 +2962,8 @@ ifelse member? "crystal" input-resource-types [
        {}
      ```
      INPUT CONTEXT:
-     - You have access to variables called input-resource-distances, input-resource-types, and weight
-     - input-resource-distances is a NetLogo list that contains three values representing distances to food in three cone regions of 20 degrees each. 
-     - input-resource-types is a NetLogo list that contains three resource types that are either “silver”, “gold” or “crystal. The input-resource-types list is parallel to the input-resource-distances list, which means their element indices correspond to the same resource.
+     - You have access to variables called input-resource-distances and weight
+     - input-resource-distances is a NetLogo list that contains three values representing distances to food in three cone regions of 20 degrees each.
      - The first item in input-resource-distances is the distance to the nearest resource in the left cone, the second is the right cone, and the third is the front cone
      - Non-zero lower values in input-resource-distances indicate closer resources
      - Use the information in this variable to inform movement strategy
@@ -3113,9 +3013,34 @@ ifelse member? "crystal" input-resource-types [
      4. Be creative in your movement strategy
      EXAMPLES OF VALID CODE GENERATION:
      Current Code: ```fd 1 rt random 45 fd 2 lt 30```
-     Changed Code: ```ifelse (item 0 input-resource-distances != 0) [ ifelse (item 0 input-resource-types = "gold") [ rt 15 fd 0.5 ] [ rt random 30 lt random 30 fd 5 ] ] [ rt random 30 lt random 30 fd 5 ]
-```
-     Why: This code uses two parallel lists—input-resource-distances and input-resource-types—to guide movement based on what's detected in the left cone. If a resource is present (non-zero distance) and it's "gold", the agent turns slightly and moves forward to approach it. Otherwise, it turns randomly and moves further to explore the environment.
+     Changed Code: ```ifelse weight > 50 [
+  if xcor > 0 [ rt 10 ]
+  if xcor < 0 [ lt 10 ]
+  if ycor > 0 [ rt 10 ]
+  if ycor < 0 [ lt 10 ]
+  fd 2
+][
+  if item 0 input-resource-distances <= item 1 input-resource-distances and item 0 input-resource-distances <= item 2 input-resource-distances [
+    if item 0 input-resource-distances < 5 [ rt 5 ]
+    lt 20
+  ]
+  if item 1 input-resource-distances <= item 0 input-resource-distances and item 1 input-resource-distances <= item 2 input-resource-distances [
+    if item 1 input-resource-distances < 5 [ lt 5 ]
+    rt 20
+  ]
+  if item 2 input-resource-distances <= item 0 input-resource-distances and item 2 input-resource-distances <= item 1 input-resource-distances [
+    if item 2 input-resource-distances < 5 [ rt 5 ]
+    rt 10
+  ]
+  if item 0 input-resource-distances > 10 and item 1 input-resource-distances > 10 and item 2 input-resource-distances > 10 [
+    if xcor > 0 [ rt 10 ]
+    if xcor < 0 [ lt 10 ]
+    if ycor > 0 [ rt 10 ]
+    if ycor < 0 [ lt 10 ]
+  ]
+  fd 1
+]```
+     Why: The code controls the movement based on its weight and input-resource-distances. If the agent is heavy (weight > 30), it returns to the center (for depositing) by turning based on its position and moving forward quickly. If it is light (weight < 30), it seeks the closest resource by comparing distances in the list and turning toward the nearest one with a small angle adjustment, then moves forward slowly. This creates a simple foraging-return behavior.
      The code must be runnable in NetLogo in the context of a turtle. Do not write any procedures and assume that the code will be run in an ask turtles block.
      Detail your strategy in netlogo code comments (;;) before you generate the implementation. Include comments throughout the code to explain your strategy.
      Return ONLY the changed NetLogo code. Do not include any explanations or outside the code block.
@@ -3183,190 +3108,156 @@ ifelse member? "crystal" input-resource-types [
      4. Be creative in your movement strategy
      EXAMPLES OF VALID CODE GENERATION:
      Current Code: ```fd 1 rt random 45 fd 2 lt 30```
-     Changed Code: ```ifelse (item 0 input-resource-distances != 0) [ ifelse (item 0 input-resource-types = "gold") [ rt 15 fd 0.5 ] [ rt random 30 lt random 30 fd 5 ] ] [ rt random 30 lt random 30 fd 5 ]```
-     Why: This code uses two parallel lists—input-resource-distances and input-resource-types—to guide movement based on what's detected in the left cone. If a resource is present (non-zero distance) and it's "gold", the agent turns slightly and moves forward to approach it. Otherwise, it turns randomly and moves further to explore the environment.
+     Changed Code: ```ifelse weight > 50 [
+  if xcor > 0 [ rt 10 ]
+  if xcor < 0 [ lt 10 ]
+  if ycor > 0 [ rt 10 ]
+  if ycor < 0 [ lt 10 ]
+  fd 2
+][
+  if item 0 input-resource-distances <= item 1 input-resource-distances and item 0 input-resource-distances <= item 2 input-resource-distances [
+    if item 0 input-resource-distances < 5 [ rt 5 ]
+    lt 20
+  ]
+  if item 1 input-resource-distances <= item 0 input-resource-distances and item 1 input-resource-distances <= item 2 input-resource-distances [
+    if item 1 input-resource-distances < 5 [ lt 5 ]
+    rt 20
+  ]
+  if item 2 input-resource-distances <= item 0 input-resource-distances and item 2 input-resource-distances <= item 1 input-resource-distances [
+    if item 2 input-resource-distances < 5 [ rt 5 ]
+    rt 10
+  ]
+  if item 0 input-resource-distances > 10 and item 1 input-resource-distances > 10 and item 2 input-resource-distances > 10 [
+    if xcor > 0 [ rt 10 ]
+    if xcor < 0 [ lt 10 ]
+    if ycor > 0 [ rt 10 ]
+    if ycor < 0 [ lt 10 ]
+  ]
+  fd 1
+]```
+     Why: The code controls movement based on agent weight and input-resource-distances. If the agent is heavy (weight > 30), it returns to the center (for depositing) by turning based on its position and moving forward quickly. If it is light (weight < 30), it seeks the closest resource by comparing distances in the list and turning toward the nearest one with a small angle adjustment, then moves forward slowly. This creates a simple foraging-return behavior.
      Current Code:
      ```
-     ifelse (item 0 input-resource-distances != 0) [
-  ifelse (item 0 input-resource-types = "gold") [
-    lt 5
-    fd 0.2
-  ] [
-    ifelse (item 1 input-resource-distances != 0) [
-      ifelse (item 1 input-resource-types = "silver") [
-        rt 5
-        fd 0.2
-      ] [
-        ifelse (item 2 input-resource-distances != 0) [
-          ifelse (item 2 input-resource-types = "crystal") [
-            fd 0.2
-          ] [
-            ifelse (random 100 < 50) [
-              fd 2
-              rt random-float 45
-            ] [
-              rt random-float 30
-              fd 5
-            ]
-          ]
-        ] [
-          ifelse (random 100 < 50) [
-            fd 2
-            rt random-float 45
-          ] [
-            rt random-float 30
-            fd 5
-          ]
-        ]
-      ]
-    ] [
-      ifelse (item 2 input-resource-distances != 0) [
-        ifelse (item 2 input-resource-types = "crystal") [
-          fd 0.2
-        ] [
-          ifelse (random 100 < 50) [
-            fd 2
-            rt random-float 45
-          ] [
-            rt random-float 30
-            fd 5
-          ]
-        ]
-      ] [
-        ifelse (random 100 < 50) [
-          fd 2
-          rt random-float 45
-        ] [
-          rt random-float 30
-          fd 5
-        ]
-      ]
-    ]
+     ifelse weight > 50 [
+  if xcor > 0 [ rt 10 ]
+  if xcor < 0 [ lt 10 ]
+  if ycor > 0 [ rt 10 ]
+  if ycor < 0 [ lt 10 ]
+  fd 2
+][
+  if item 0 input-resource-distances <= item 1 input-resource-distances and item 0 input-resource-distances <= item 2 input-resource-distances [
+    if item 0 input-resource-distances < 5 [ rt 5 ]
+    lt 20
   ]
-] [
-  ifelse (item 1 input-resource-distances != 0) [
-    ifelse (item 1 input-resource-types = "silver") [
-      rt 5
-      fd 0.2
-    ] [
-      ifelse (item 2 input-resource-distances != 0) [
-        ifelse (item 2 input-resource-types = "crystal") [
-          fd 0.2
-        ] [
-          ifelse (random 100 < 50) [
-            fd 2
-            rt random-float 45
-          ] [
-            rt random-float 30
-            fd 5
-          ]
-        ]
-      ] [
-        ifelse (random 100 < 50) [
-          fd 2
-          rt random-float 45
-        ] [
-          rt random-float 30
-          fd 5
-        ]
-      ]
-    ]
-  ] [
-    ifelse (item 2 input-resource-distances != 0) [
-      ifelse (item 2 input-resource-types = "crystal") [
-        fd 0.2
-      ] [
-        ifelse (random 100 < 50) [
-          fd 2
-          rt random-float 45
-        ] [
-          rt random-float 30
-          fd 5
-        ]
-      ]
-    ] [
-      ifelse (random 100 < 50) [
-        fd 2
-        rt random-float 45
-      ] [
-        rt random-float 30
-        fd 5
-      ]
-    ]
+  if item 1 input-resource-distances <= item 0 input-resource-distances and item 1 input-resource-distances <= item 2 input-resource-distances [
+    if item 1 input-resource-distances < 5 [ lt 5 ]
+    rt 20
   ]
+  if item 2 input-resource-distances <= item 0 input-resource-distances and item 2 input-resource-distances <= item 1 input-resource-distances [
+    if item 2 input-resource-distances < 5 [ rt 5 ]
+    rt 10
+  ]
+  if item 0 input-resource-distances > 10 and item 1 input-resource-distances > 10 and item 2 input-resource-distances > 10 [
+    if xcor > 0 [ rt 10 ]
+    if xcor < 0 [ lt 10 ]
+    if ycor > 0 [ rt 10 ]
+    if ycor < 0 [ lt 10 ]
+  ]
+  fd 1
 ]
+     
      ```
      Changed Code:
      ```
-     ;; Prioritize: crystal > gold > silver
-ifelse member? "crystal" input-resource-types and any? map [i -> (item i input-resource-types = "crystal") and (item i input-resource-distances != 0)] [0 1 2] [
-  
-  ;; Find closest crystal
-  ifelse (item 0 input-resource-types = "crystal" and item 0 input-resource-distances != 0) and
-         ((item 1 input-resource-types != "crystal") or (item 0 input-resource-distances <= item 1 input-resource-distances)) and
-         ((item 2 input-resource-types != "crystal") or (item 0 input-resource-distances <= item 2 input-resource-distances)) [
-    lt 5
-    fd 0.2
-  ] [
-    ifelse (item 1 input-resource-types = "crystal" and item 1 input-resource-distances != 0) and
-           ((item 0 input-resource-types != "crystal") or (item 1 input-resource-distances <= item 0 input-resource-distances)) and
-           ((item 2 input-resource-types != "crystal") or (item 1 input-resource-distances <= item 2 input-resource-distances)) [
-      rt 5
-      fd 0.2
-    ] [
-      fd 0.2
+ifelse weight > 50 [
+  if xcor > 0 [ rt 10 ]
+  if xcor < 0 [ lt 10 ]
+  if ycor > 0 [ rt 10 ]
+  if ycor < 0 [ lt 10 ]
+  fd 2
+][
+  if item 0 input-resource-distances <= item 1 input-resource-distances and item 0 input-resource-distances <= item 2 input-resource-distances [
+    if item 0 input-resource-distances < 5 [ rt 5 ]
+    lt 20
+    fd 1.5
+  ]
+  if item 1 input-resource-distances <= item 0 input-resource-distances and item 1 input-resource-distances <= item 2 input-resource-distances [
+    if item 1 input-resource-distances < 5 [ lt 5 ]
+    rt 20
+    fd 1.5
+  ]
+  if item 2 input-resource-distances <= item 0 input-resource-distances and item 2 input-resource-distances <= item 1 input-resource-distances [
+    if item 2 input-resource-distances < 5 [ rt 5 ]
+    rt 10
+    fd 1.5
+  ]
+  if item 0 input-resource-distances > 10 and item 1 input-resource-distances > 10 and item 2 input-resource-distances > 10 [
+    if abs(xcor) > abs(ycor) [ 
+      if xcor > 0 [ rt 10 ]
+      if xcor < 0 [ lt 10 ]
+    ]
+    if abs(xcor) < abs(ycor) [ 
+      if ycor > 0 [ rt 10 ]
+      if ycor < 0 [ lt 10 ]
+    ]
+    if abs(xcor) = 0 and abs(ycor) = 0 [ fd 1 ]
+    fd 1
+  ]
+  if item 0 input-resource-distances > 5 and item 1 input-resource-distances > 5 and item 2 input-resource-distances > 5 [
+    if xcor > 0 [ rt 5 ]
+    if xcor < 0 [ lt 5 ]
+    if ycor > 0 [ rt 5 ]
+    if ycor < 0 [ lt 5 ]
+    fd 1
+  ]
+  if xcor = 0 and ycor = 0 [
+    if item 0 input-resource-distances < item 1 input-resource-distances and item 0 input-resource-distances < item 2 input-resource-distances [
+      if item 0 input-resource-distances < 5 [ rt 5 ]
+      lt 20
+      fd 1.5
+    ]
+    if item 1 input-resource-distances < item 0 input-resource-distances and item 1 input-resource-distances < item 2 input-resource-distances [
+      if item 1 input-resource-distances < 5 [ lt 5 ]
+      rt 20
+      fd 1.5
+    ]
+    if item 2 input-resource-distances < item 0 input-resource-distances and item 2 input-resource-distances < item 1 input-resource-distances [
+      if item 2 input-resource-distances < 5 [ rt 5 ]
+      rt 10
+      fd 1.5
     ]
   ]
-] [
-  ifelse member? "gold" input-resource-types and any? map [i -> (item i input-resource-types = "gold") and (item i input-resource-distances != 0)] [0 1 2] [
-    ;; Find closest gold
-    ifelse (item 0 input-resource-types = "gold" and item 0 input-resource-distances != 0) and
-           ((item 1 input-resource-types != "gold") or (item 0 input-resource-distances <= item 1 input-resource-distances)) and
-           ((item 2 input-resource-types != "gold") or (item 0 input-resource-distances <= item 2 input-resource-distances)) [
-      lt 5
-      fd 0.2
-    ] [
-      ifelse (item 1 input-resource-types = "gold" and item 1 input-resource-distances != 0) and
-             ((item 0 input-resource-types != "gold") or (item 1 input-resource-distances <= item 0 input-resource-distances)) and
-             ((item 2 input-resource-types != "gold") or (item 1 input-resource-distances <= item 2 input-resource-distances)) [
-        rt 5
-        fd 0.2
-      ] [
-        fd 0.2
-      ]
-    ]
-  ] [
-    ifelse member? "silver" input-resource-types and any? map [i -> (item i input-resource-types = "silver") and (item i input-resource-distances != 0)] [0 1 2] [
-      ;; Find closest silver
-      ifelse (item 0 input-resource-types = "silver" and item 0 input-resource-distances != 0) and
-             ((item 1 input-resource-types != "silver") or (item 0 input-resource-distances <= item 1 input-resource-distances)) and
-             ((item 2 input-resource-types != "silver") or (item 0 input-resource-distances <= item 2 input-resource-distances)) [
-        lt 5
-        fd 0.2
-      ] [
-        ifelse (item 1 input-resource-types = "silver" and item 1 input-resource-distances != 0) and
-               ((item 0 input-resource-types != "silver") or (item 1 input-resource-distances <= item 0 input-resource-distances)) and
-               ((item 2 input-resource-types != "silver") or (item 1 input-resource-distances <= item 2 input-resource-distances)) [
-          rt 5
-          fd 0.2
-        ] [
-          fd 0.2
-        ]
-      ]
-    ] [
-      ;; Default random explore behavior
-      ifelse random 100 < 50 [
-        fd 2
-        rt random-float 45
-      ] [
-        rt random-float 30
-        fd 5
-      ]
-    ]
+  if abs(xcor) < 5 and abs(ycor) < 5 and weight > 10 [
+    if xcor > 0 [ rt 10 ]
+    if xcor < 0 [ lt 10 ]
+    if ycor > 0 [ rt 10 ]
+    if ycor < 0 [ lt 10 ]
+    fd 2
+  ]
+  if abs(xcor) < 10 and abs(ycor) < 10 and weight > 20 [
+    if xcor > 0 [ rt 10 ]
+    if xcor < 0 [ lt 10 ]
+    if ycor > 0 [ rt 10 ]
+    if ycor < 0 [ lt 10 ]
+    fd 2
+  ]
+  if abs(xcor) > 10 or abs(ycor) > 10 and weight < 10 [
+    if xcor > 0 [ lt 5 ]
+    if xcor < 0 [ rt 5 ]
+    if ycor > 0 [ lt 5 ]
+    if ycor < 0 [ rt 5 ]
+    fd 1
+  ]
+  if weight > 30 [
+    if xcor > 0 [ rt 10 ]
+    if xcor < 0 [ lt 10 ]
+    if ycor > 0 [ rt 10 ]
+    if ycor < 0 [ lt 10 ]
+    fd 2
   ]
 ]
      ```
-     Why: This code directs the agent to move toward the closest instance of the highest-value resource it can detect—crystal first, then gold, then silver—based on distances in three vision cones (left, right, front), and defaults to random wandering if no resources are seen.
+     Why: The evolved code adds more nuanced behaviors based on the agent's position, weight, and proximity to resources. It introduces finer movement control (fd 1.5), special cases for being near or at the center, and multiple fallback strategies to improve adaptability. These changes help the agent navigate more intelligently, avoid getting stuck, and better balance between exploring and returning behavior.
      The code must be runnable in NetLogo in the context of a turtle. Do not write any procedures and assume that the code will be run in an ask turtles block.
      Detail your strategy in netlogo code comments (;;) before you generate the implementation. Include comments throughout the code to explain your strategy.
      Return ONLY the changed NetLogo code. Do not include any explanations or outside the code block.


### PR DESCRIPTION
**PR Details:**
- Changed resource spawning back to random location
- Changed prompt examples and removed input_resource_types from LLM prompt, encouraging it to use only input_resource_distances and weight variables. 
- Changed resource-score decay rate to 0.03
- Changed resource type spawn to be proportionate to value/weight. Crystals are rarer, gold is uncommon, and silver is common.